### PR TITLE
Playlist glitch in Firefox

### DIFF
--- a/src/Musicus/Styles/main.scss
+++ b/src/Musicus/Styles/main.scss
@@ -378,7 +378,6 @@ body{
 
 .queue-list-item {
   width: 100%;
-  height: 6%;
   align-items:center;
   display: flex;
   padding-left: 15px;


### PR DESCRIPTION
Resolved #10. The height is now rendered properly in Firefox and Chrome.