### PR TITLE
Jingle volume fixes

### DIFF
--- a/src/Musicus.MusicServices/Musicus.FileSystemService/FileSystemServiceConfiguration.cs
+++ b/src/Musicus.MusicServices/Musicus.FileSystemService/FileSystemServiceConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Musicus.Abstractions.Services;
 
@@ -8,13 +9,19 @@ namespace Musicus.FileSystemService
 	{
 		public static IServiceCollection AddFileSystemMusicService(this IServiceCollection services, string filePath)
 		{
+			if (!File.Exists(filePath))
+			{
+				filePath = Environment.GetFolderPath(Environment.SpecialFolder.MyMusic);
+				Console.WriteLine($"The provided filepath was not found, we are now using {filePath} as the music folder.");
+			}
+
 			if (!string.IsNullOrEmpty(filePath))
 			{
 				services.AddTransient<IMusicService>(s => new FileSystemMusicService(filePath));
 			}
 			else
 			{
-				throw new ArgumentException("ClientId and/or ClientSecret are not provided! If you're not in possession of the Spotify credentials, consider disabling this service");
+				throw new ArgumentException("The filesystem music service cannot find the specified and the Music folder on your machine.");
 			}
 			return services;
 		}

--- a/src/Musicus.MusicServices/Musicus.FileSystemService/Helpers/FileSystemHelper.cs
+++ b/src/Musicus.MusicServices/Musicus.FileSystemService/Helpers/FileSystemHelper.cs
@@ -83,7 +83,7 @@ namespace Musicus.FileSystemService.Helpers
 						TrackLength = audioFile != null ? int.Parse(audioFile?.Duration.TotalMilliseconds.ToString()) : -1,
 						Url = file.FullName,
 						TrackSource = TrackSource.FileSystem,
-						Icon = "hdd icon"
+						Icon = "hdd outline icon"
 					});
 
 					vlcPlayer.Stop();
@@ -187,13 +187,18 @@ namespace Musicus.FileSystemService.Helpers
 			return ActionResult<IMusicServiceStatus>.Success(_currentStatus);
 		}
 
-		public static IActionResult<float> GetVolume() => ActionResult<float>.Success(VlcPlayer.Audio.Volume);
+		public static IActionResult<float> GetVolume()
+		{
+			var result = (int)(Math.Exp(VlcPlayer.Audio.Volume / 21) + 4.6131);
+			return ActionResult<float>.Success((float)result);
+		}
 
 		public static IActionResult<float> SetVolume(float volume)
 		{
-			VlcPlayer.Audio.Volume = (int)volume;
+			var vlcVolume = (int)(21.7 * Math.Log(volume) - 4.6131);
+			VlcPlayer.Audio.Volume = vlcVolume;
 
-			return ActionResult<float>.Success(VlcPlayer.Audio.Volume);
+			return ActionResult<float>.Success(vlcVolume);
 		}
 
 		public static IActionResult<bool> Stop()

--- a/src/Musicus.MusicServices/Musicus.YouTubeService/Helpers/YouTubeHelper.cs
+++ b/src/Musicus.MusicServices/Musicus.YouTubeService/Helpers/YouTubeHelper.cs
@@ -131,13 +131,19 @@ namespace Musicus.YouTubeService.Helpers
 			return ActionResult<IMusicServiceStatus>.Success(_currentStatus);
 		}
 
-		public static IActionResult<float> GetVolume() => ActionResult<float>.Success(VlcPlayer.Audio.Volume);
+		public static IActionResult<float> GetVolume()
+		{
+			var result = (int)(Math.Exp(VlcPlayer.Audio.Volume / 21) + 4.6131);
+
+			return ActionResult<float>.Success((float)result);
+		}
 
 		public static IActionResult<float> SetVolume(float volume)
 		{
-			VlcPlayer.Audio.Volume = (int)volume;
+			var vlcVolume = (int)(21.7 * Math.Log(volume) - 4.6131);       
+			VlcPlayer.Audio.Volume = vlcVolume;
 
-			return ActionResult<float>.Success(VlcPlayer.Audio.Volume);
+			return ActionResult<float>.Success(vlcVolume);
 		}
 
 		public static IActionResult<bool> Stop()

--- a/src/Musicus/ApiControllers/MusicusController.cs
+++ b/src/Musicus/ApiControllers/MusicusController.cs
@@ -131,9 +131,11 @@ namespace Musicus.ApiControllers
 		public async Task<IActionResult> PlayJingleAsync([FromBody] string filePath)
 		{
 			const int reduceVolumePercentage = 50;
-			var newVolume = Player.DefaultMusicServiceVolumeLevel - ((Player.DefaultMusicServiceVolumeLevel / 100) * reduceVolumePercentage);
-
 			var currentTrack = Playlist.GetCurrentTrack();
+
+			var startingVolume = _player.GetVolumeAsync(currentTrack.TrackSource);
+			var newVolume = startingVolume.Result - ((startingVolume.Result / 100) * reduceVolumePercentage);
+
 			if (currentTrack != null)
 			{
 				_player.SetVolume(new VolumeFilter { TrackSource = currentTrack.TrackSource, Volume = newVolume });
@@ -143,7 +145,7 @@ namespace Musicus.ApiControllers
 
 			if (currentTrack != null)
 			{
-				_player.SetVolume(new VolumeFilter { TrackSource = currentTrack.TrackSource, Volume = Player.DefaultMusicServiceVolumeLevel });
+				_player.SetVolume(new VolumeFilter { TrackSource = currentTrack.TrackSource, Volume = startingVolume.Result });
 			}
 
 			return Ok();

--- a/src/Musicus/Helpers/JingleHelper.cs
+++ b/src/Musicus/Helpers/JingleHelper.cs
@@ -37,7 +37,7 @@ namespace Musicus.Helpers
 
 		public static void InitVolume(float volume)
 		{
-			//VlcPlayer.Audio.Volume = 200;
+			VlcPlayer.Audio.Volume = 200;
 		}
 
 		public static IEnumerable<Jingle> GetJingles()

--- a/src/Musicus/Helpers/JingleHelper.cs
+++ b/src/Musicus/Helpers/JingleHelper.cs
@@ -37,7 +37,7 @@ namespace Musicus.Helpers
 
 		public static void InitVolume(float volume)
 		{
-			VlcPlayer.Audio.Volume = 200;
+			//VlcPlayer.Audio.Volume = 200;
 		}
 
 		public static IEnumerable<Jingle> GetJingles()

--- a/src/Musicus/Startup.cs
+++ b/src/Musicus/Startup.cs
@@ -70,7 +70,7 @@ namespace Musicus
 		private void SetMusicServices(IServiceCollection services)
 		{
 			services.AddFileSystemMusicService(Configuration["FileSystemMusicServiceFilePath"]);
-			services.AddSpotifyMusicService(Configuration["SpotifyClientId"], Configuration["SpotifyClientSecret"]);
+			//services.AddSpotifyMusicService(Configuration["SpotifyClientId"], Configuration["SpotifyClientSecret"]);
 			services.AddYouTubeMusicService();
 		}
 	}


### PR DESCRIPTION
Some jingle volume fixes.
Turns out, VLC uses another scale then Windows for volume, I tried to fix this with a formula which is near perfect in accuracy but it is a bit clunky.

Also I disabled Spotify, because the API is not longer going to work. See: https://github.com/JohnnyCrazy/SpotifyAPI-NET/issues/254

![afbeelding](https://user-images.githubusercontent.com/40266212/43424960-669398b6-9451-11e8-9140-5c601f492336.png)
